### PR TITLE
Fixing typo in the installation instructions

### DIFF
--- a/index.md
+++ b/index.md
@@ -55,7 +55,7 @@ Get installation packages from [Github Release](https://github.com/hamler-lang/h
 
 ```shell
 $ tar zxvf hamler-$version.tgz -C /usr/lib/hamler
-$ ln -s /usr/lib/hamler/bin/hamer /usr/bin/hamler
+$ ln -s /usr/lib/hamler/bin/hamler /usr/bin/hamler
 ```
 
 **Centos 7**


### PR DESCRIPTION
Also, I noticed that the latest release wasn't gzipped, which caused a small problem because the file extension is `tgz`. Thanks for your work on Hamler! ❤️ 